### PR TITLE
Fix change hardcoded source path

### DIFF
--- a/bootstrap-module-installer.sh
+++ b/bootstrap-module-installer.sh
@@ -25,7 +25,7 @@ readonly DEFAULT_FETCH_VERSION="v0.3.2"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 
-readonly MODULE_INSTALLER_DOWNLOAD_URL_BASE="https://raw.githubusercontent.com/craftech-io/module-installer/tree/fix_change-hardcoded-source-path"
+readonly MODULE_INSTALLER_DOWNLOAD_URL_BASE="https://raw.githubusercontent.com/craftech-io/module-installer"
 readonly MODULE_INSTALLER_INSTALL_PATH="$BIN_DIR/module-install"
 readonly MODULE_INSTALLER_SCRIPT_NAME="module-install"
 

--- a/bootstrap-module-installer.sh
+++ b/bootstrap-module-installer.sh
@@ -25,7 +25,7 @@ readonly DEFAULT_FETCH_VERSION="v0.3.2"
 readonly FETCH_DOWNLOAD_URL_BASE="https://github.com/gruntwork-io/fetch/releases/download"
 readonly FETCH_INSTALL_PATH="$BIN_DIR/fetch"
 
-readonly MODULE_INSTALLER_DOWNLOAD_URL_BASE="https://raw.githubusercontent.com/craftech-io/module-installer"
+readonly MODULE_INSTALLER_DOWNLOAD_URL_BASE="https://raw.githubusercontent.com/craftech-io/module-installer/tree/fix_change-hardcoded-source-path"
 readonly MODULE_INSTALLER_INSTALL_PATH="$BIN_DIR/module-install"
 readonly MODULE_INSTALLER_SCRIPT_NAME="module-install"
 

--- a/module-install
+++ b/module-install
@@ -132,7 +132,7 @@ function fetch_script_module {
   # Note that fetch can safely handle blank arguments for --tag or --branch
   # If both --tag and --branch are specified, --branch will be used
   log_info "Downloading module $module_name from $repo"
-  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="/modules/$module_name" "$download_dir/$module_name"
+  fetch --repo="$repo" --tag="$tag" --branch="$branch" --source-path="$module_name" "$download_dir/$module_name"
 }
 
 # Download a binary asset from a GitHub release using fetch (https://github.com/module-io/fetch)


### PR DESCRIPTION
# Fix

- Removed the hardcoded values in the `source-path` variable.

This allow us to have a more flexible repository structure specially when we fork Craftech's repositories to offboarding clients.  